### PR TITLE
Update current role to Anthropic

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@ title: Blithe Rocher, PhD
 ---
 
 <h2>About</h2>
-<p>Blithe Rocher is an engineering manager based in Alameda, California. She leads engineering teams at <a href="https://google.com">Google</a>  to help people develop and deploy highly scalable applications and functions on a fully managed  <a href="https://cloud.google.com/serverless">serverless platform</a>.  Prior to focusing on software engineering, she received a PhD in physical chemistry from the <a href="http://www.usc.edu">University of Southern California</a>.</p>
+<p>Blithe Rocher is an engineering manager based in Alameda, California. She leads an engineering team at <a href="https://anthropic.com">Anthropic</a> supporting the frontend for <a href="https://claude.ai">claude.ai</a>.  Prior to focusing on software engineering, she received a PhD in physical chemistry from the <a href="http://www.usc.edu">University of Southern California</a>.</p>
 
 <p>When she's not focused on tech, Blithe is watching baseball, reading books, or spending time with her family.</p>

--- a/resume.html
+++ b/resume.html
@@ -18,7 +18,13 @@ title: Blithe Rocher, PhD | R&eacute;sum&eacute;
   <h3>Professional Experience</h3>
 
   <div class="job">
-    <div class="job-header">Engineering Manager, May 2022 &ndash; Present</div>
+    <div class="job-header">Engineering Manager, March 2026 &ndash; Present</div>
+    <div class="job-meta"><a href="https://anthropic.com">Anthropic</a> &middot; San Francisco, CA</div>
+    <p>Blithe leads an engineering team at Anthropic supporting the frontend for <a href="https://claude.ai">claude.ai</a>.</p>
+  </div>
+
+  <div class="job">
+    <div class="job-header">Engineering Manager, May 2022 &ndash; March 2026</div>
     <div class="job-meta"><a href="https://google.com">Google</a> &middot; San Francisco, CA</div>
     <p>As an Engineering Manager at Google, Blithe manages teams and engineering managers in the Serverless organization.</p>
     <p>Blithe focuses on the growth of her team members and the iterative improvement of organizational processes to ensure teams are delivering high-quality user experiences and maintainable engineering infrastructure.</p>


### PR DESCRIPTION
## Summary

- **`index.html`**: Updated bio to reflect new role — now reads "She leads an engineering team at Anthropic supporting the frontend for claude.ai."
- **`resume.html`**: Added new current-role entry for Anthropic (Engineering Manager, March 2026 - Present); updated Google entry date to "May 2022 - March 2026" with original description preserved as historical context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)